### PR TITLE
Restructure CV layout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
           command: wget https://raw.githubusercontent.com/liantze/AltaCV/108e60d66cedc74c16ecfe00a262323c8ec36d64/altacv.cls
       - run:
           name: Replace email address placeholder
-          command: ls ./cv_sections/*.tex | xargs sed -i "s/REPLACE_ME_FROM_ENVIRONMENT_email_REPLACE_ME_FROM_ENVIRONMENT/${EMAIL}/g"
+          command: ls ./cv_sections/*.tex | xargs sed -i "s/REPLACE_email_REPLACE/${EMAIL}/g"
       - run:
           name: Replace website address placeholder
-          command: ls ./cv_sections/*.tex | xargs sed -i "s/REPLACE_ME_FROM_ENVIRONMENT_website_REPLACE_ME_FROM_ENVIRONMENT/${WEBSITE}/g"
+          command: ls ./cv_sections/*.tex | xargs sed -i "s/REPLACE_website_REPLACE/${WEBSITE}/g"
       - run:
           name: Compile LaTeX document
           command: latexmk -pdf

--- a/tex/bamber_jon_cv.tex
+++ b/tex/bamber_jon_cv.tex
@@ -49,13 +49,8 @@
 
   \makecvheader
 
-  \vspace{0.5cm}
-  \input{./cv_sections/summary.tex}
-
-  \vspace{0.5cm}
-  \input{./cv_sections/experience.tex}
-
+  \input{./cv_sections/page_1.tex}
   \newpage
-  \input{./cv_sections/skills.tex}
+  \input{./cv_sections/page_2.tex}
 
 \end{document}

--- a/tex/cv_sections/certifications.tex
+++ b/tex/cv_sections/certifications.tex
@@ -1,0 +1,46 @@
+\cvsection{Certifications}
+
+\vspace{0.25cm}
+
+\cvsubsection{Cloud/DevOps}
+
+\begin{itemize}[leftmargin=0.5cm]
+  \begin{small}
+    \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/9fa8d5c9941c306a}{Microsoft Certified: DevOps Engineer Expert}
+    \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/dfc55b2ee2422f60}{Microsoft Certified: Azure Administrator Associate}
+    \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/508432a7f7252b38}{Microsoft Certified: Azure Fundamentals}
+    \item \href{https://www.credly.com/badges/4d6f1742-7c27-4d07-ba0d-964210b6a2e5/public_url}{AWS Certified Solutions Architect - Associate}
+    \item \href{https://www.credly.com/badges/59c984ed-dce0-4716-9969-993f76808701/public_url}{AWS Certified SysOps Administrator - Associate}
+    \item \href{https://www.credly.com/badges/51e0bffd-6a77-4d74-adce-40c06015ce86/public_url}{AWS Certified Developer - Associate}
+    \item \href{https://www.credly.com/badges/5db53ec6-0fb1-4ae4-99c7-6a1b3ac22302/public_url}{AWS Certified Cloud Practitioner}
+    \item \href{https://www.credly.com/badges/01c9e4c4-97fa-4a7d-ab58-bf46955d4085}{Hashicorp Certified: Terraform Associate}
+  \end{small}
+\end{itemize}
+
+\vspace{0.25cm}
+
+\cvsubsection{Security}
+
+\begin{itemize}[leftmargin=0.5cm]
+  \begin{small}
+    \item \href{https://www.credly.com/badges/00ee07f4-0640-40a3-b4b5-5a6d65f5a2df}{NIST Cybersecurity Framework Professional Practitioner}
+    \item \href{https://www.credly.com/badges/357158a5-75ae-4649-97eb-cc1c9829b2f9}{CompTIA Security+}
+    \item \href{https://aspen.eccouncil.org/VerifyBadge?type=certification&a=UR85u9BGOO5V+b6Nq1cbrqvuDkKDQsqZVZzAAnDrtQc=}{EC-Council Certified Ethical Hacker}
+  \end{small}
+\end{itemize}
+
+\vspace{0.25cm}
+
+\cvsubsection{Artificial Intelligence \& Machine Learning}
+
+\begin{itemize}[leftmargin=0.5cm]
+  \begin{small}
+    \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/dd17d03fc8e825ff}{Microsoft Certified: Azure AI Fundamentals}
+    \item \href{https://www.coursera.org/account/accomplishments/verify/DZ75HEAM5S43}{DeepLearning.AI: Machine Learning}
+    \item \href{https://www.coursera.org/account/accomplishments/specialization/93CPQS55488S}{DeepLearning.AI: Deep Learning Specialization}
+  \end{small}
+\end{itemize}
+
+\vspace{0.25cm}
+
+\smallskip

--- a/tex/cv_sections/cv_header.tex
+++ b/tex/cv_sections/cv_header.tex
@@ -2,8 +2,8 @@
 \name{Jon Bamber}
 \tagline{DevOps Engineer}
 \personalinfo{
-  \mailaddress{REPLACE_ME_FROM_ENVIRONMENT_email_REPLACE_ME_FROM_ENVIRONMENT}
-  \homepage{REPLACE_ME_FROM_ENVIRONMENT_website_REPLACE_ME_FROM_ENVIRONMENT}
+  \mailaddress{REPLACE_email_REPLACE}
+  \homepage{REPLACE_website_REPLACE}
   \linkedin{jonbamber}
   \github{jonbamber}
   \location{Cardiff, UK}

--- a/tex/cv_sections/education.tex
+++ b/tex/cv_sections/education.tex
@@ -1,0 +1,20 @@
+\cvsection{Education}
+
+\vspace{0.25cm}
+
+\cvevent{\normalsize MSc Cloud Computing (\emph{in progress})}{
+  \small
+  \href{https://www.mtu.ie/}{Munster Technological University}
+}{}{}
+\cvevent{\normalsize MRes Neuroinformatics}{
+  \small
+  \href{https://www.ed.ac.uk}{University of Edinburgh}
+}{}{}
+\cvevent{\normalsize MSc Computational Science}{
+  \small
+  \href{https://www.manchester.ac.uk}{University of Manchester}
+}{}{}
+\cvevent{\normalsize BSc Mathematics}{
+  \small
+  \href{https://www.manchester.ac.uk}{University of Manchester}
+}{}{}

--- a/tex/cv_sections/experience.tex
+++ b/tex/cv_sections/experience.tex
@@ -1,105 +1,65 @@
+\vspace{0.05cm}
 \cvsection{Experience}
 
-\columnratio{0.5}
+\vspace{0.25cm}
 
-\begin{paracol}{2}
+\cvevent{DevOps Engineer}{
+  \href{https://www.mobilise.Cloud/}{Mobilise Cloud}
+}{Jul 2022 -- \emph{present}}{}
+\begin{itemize}[leftmargin=0.55cm]
+  \begin{small}
+    \item Worked as a member of Agile multi-functional teams (both in-house and embedded in client teams)
+    \item Authored and reviewed technical designs and proposals
+    \item Configured Cloud resources via Infrastructure as Code on Azure and AWS, from the level of single VM/container instances to full landing zones
+    \item Designed and implemented pipelines for infrastructure deployment, app build/release, automated testing, etc.
+    \item Created and maintained custom virtual machine images
+    \item Developed and deployed serverless functions
+    \item Implemented monitoring and alerting solutions
+    \item Automated application/package lifecycle management and artifact feeds
+    \item Troubleshooted and resolved Cloud/DevOps issues
+    \item Mentored junior team members
+  \end{small}
+\end{itemize}
 
-  %=============================== FIRST COLUMN ===============================
+\divider
 
-  \vspace{0.25cm}
+\cvevent{DevOps Engineer}{
+  \href{https://www.qa.com}{QA Consulting}
+}{Oct 2018 -- Jun 2022}{}
+\begin{itemize}[leftmargin=0.75cm]
+  \begin{small}
+    \item Worked as an integral part of a small Agile team
+    \item Used Terraform to manage AWS infrastructure
+    \item Maintained RHEL-based Data Science applications hosted in AWS, backed by data in S3 and RDS
+    \item Created virtual machine images using Packer and Ansible
+    \item Collaborated with with Data Science colleagues to support model development
+    \item Developed and maintained Jenkins pipelines for deployment and testing of Cloud infrastructure
+    \item Implemented monitoring and alerting systems
+    \item Analysed and reviewed technical infrastructure designs
+  \end{small}
+\end{itemize}
 
-  % job details
-  \cvevent{DevOps Engineer}{
-    \href{https://www.mobilise.Cloud/}{Mobilise Cloud}
-  }{Jun 2021 -- \emph{present}}{Cardiff, UK}
-  \begin{itemize}[leftmargin=0.55cm]
-    \begin{small}
-      \item Worked as a member of Agile multi-functional teams (both in-house and embedded in client teams)
-      \item Authored and reviewed technical designs and proposals
-      \item Managed Cloud resources via Infrastructure as Code
-      \item Designed and implemented pipelines for infrastructure deployment, app build/release, automated testing, etc.
-      \item Created and maintained custom virtual machine images
-      \item Developed and deployed serverless functions
-      \item Implemented monitoring \& alerting solutions
-      \item Automated application/package lifecycle management and artifact feeds
-      \item Troubleshooted and resolved Cloud/DevOps issues
-      \item Mentored junior team members
-    \end{small}
-  \end{itemize}
+\divider
 
-  %===============================
+\cvevent{Sessional Lecturer in Applied Statistics}{
+  \href{https://www.worcester.ac.uk}{University of Worcester}
+}{Aug 2017 -- Sep 2018}{}
+\begin{itemize}[leftmargin=0.75cm]
+  \begin{small}
+    \item Available for giving lectures on specialised statistical methods
+  \end{small}
+\end{itemize}
 
-  \vspace{0.2cm}\divider\vspace{0.2cm}
+\divider
 
-  % job details
-  \cvevent{DevOps Engineer}{
-    \href{https://www.aviva.co.uk}{Aviva}
-  }{Feb 2019 -- Feb 2021}{Norwich, UK}
-  \begin{itemize}[leftmargin=0.75cm]
-    \begin{small}
-      \item Worked as an integral part of a small Agile team
-      \item Used Terraform to manage AWS infrastructure
-      \item Maintained RHEL-based Data Science applications hosted in AWS, backed by data in S3 and RDS
-      \item Created virtual machine images using Packer \& Ansible
-      \item Collaborated with with Data Science colleagues to support model development
-      \item Developed and maintained Jenkins pipelines for deployment \& testing of Cloud infrastructure
-      \item Implemented monitoring \& alerting systems
-      \item Analysed and reviewed technical infrastructure designs
-    \end{small}
-  \end{itemize}
-
-  %=============================== SECOND COLUMN ===============================
-
-  \switchcolumn
-
-  \vspace{0.25cm}
-
-  % job details
-  \cvevent{IT Consultant}{
-    \href{https://www.qa.com}{QA Consulting}
-  }{Oct 2018 -- Jun 2022}{UK}
-  \begin{itemize}[leftmargin=0.75cm]
-    \begin{small}
-      \item Worked with various clients on custom DevOps projects
-      \item Built and maintained Cloud infrastructure using Terraform
-      \item Developed machine images using Packer \& Ansible
-      \item Implemented pipelines for automated builds/deployments
-    \end{small}
-  \end{itemize}
-
-  %===============================
-
-  \vspace{0.35cm}\divider\vspace{0.7cm}
-
-  % job details
-  \cvevent{Sessional Lecturer in Applied Statistics}{
-    \href{https://www.worcester.ac.uk}{University of Worcester}
-  }{Aug 2017 -- Sep 2018}{
-    \href{https://goo.gl/maps/ifptvBcT6eRuc5Pq8}{Worcester, UK}
-  }
-  \begin{itemize}[leftmargin=0.75cm]
-    \begin{small}
-      \item Available for giving lectures on specialised statistical methods
-    \end{small}
-  \end{itemize}
-
-  %===============================
-
-  \vspace{0.7cm}\divider\vspace{0.7cm}
-
-  % job details
-  \cvevent{Researcher in Computational Neuroscience}{
-    \href{https://www.ed.ac.uk}{University of Edinburgh}
-  }{Jan 2013 -- Jul 2017}{
-    \href{https://goo.gl/maps/ZxJEeHJvAbNaWTdw6}{Edinburgh, UK}
-  }
-  \begin{itemize}[leftmargin=0.75cm]
-    \begin{small}
-      \item Iteratively generated and tested scientific hypotheses
-      \item Wrote and applied bespoke statistical \& information theoretic data analysis scripts/tools
-      \item Developed computational models to test hypotheses and explain experimentally observed phenomena
-      \item Reported findings in documents, presentations, papers, etc.
-    \end{small}
-  \end{itemize}
-
-\end{paracol}
+\cvevent{Researcher in Computational Neuroscience}{
+  \href{https://www.ed.ac.uk}{University of Edinburgh}
+}{Jan 2013 -- Jul 2017}{}
+\begin{itemize}[leftmargin=0.75cm]
+  \begin{small}
+    \item Iteratively generated and tested scientific hypotheses
+    \item Wrote and applied bespoke statistical and information theoretic data analysis scripts/tools
+    \item Developed computational models to test hypotheses and explain experimentally observed phenomena
+    \item Reported findings in documents, presentations, papers, etc.
+  \end{small}
+\end{itemize}

--- a/tex/cv_sections/page_1.tex
+++ b/tex/cv_sections/page_1.tex
@@ -1,0 +1,15 @@
+\columnratio{0.35}
+
+\begin{paracol}{2}
+
+  %=============================== FIRST COLUMN ===============================
+
+  \input{./cv_sections/summary.tex}
+
+  %=============================== SECOND COLUMN ===============================
+
+  \switchcolumn
+
+  \input{./cv_sections/experience.tex}
+
+\end{paracol}

--- a/tex/cv_sections/page_2.tex
+++ b/tex/cv_sections/page_2.tex
@@ -1,0 +1,16 @@
+\columnratio{0.49}
+
+\begin{paracol}{2}
+
+  %=============================== FIRST COLUMN ===============================
+
+  \input{./cv_sections/certifications.tex}
+  \input{./cv_sections/education.tex}
+
+  %=============================== SECOND COLUMN ===============================
+
+  \switchcolumn
+
+  \input{./cv_sections/skills.tex}
+
+\end{paracol}

--- a/tex/cv_sections/skills.tex
+++ b/tex/cv_sections/skills.tex
@@ -1,182 +1,95 @@
+% tags for DevOps tools
+\cvsection{DevOps Tools}
 
-\columnratio{0.5}
+\vspace{0.25cm}
 
-\begin{paracol}{2}
+\cvtag{\footnotesize Azure}
+\cvtag{\footnotesize AWS}
+\cvtag{\footnotesize Terraform}
+\cvtag{\footnotesize ARM Templates}
+\cvtag{\footnotesize CloudFormation}
+\cvtag{\footnotesize Packer}
+\cvtag{\footnotesize Docker}
+\cvtag{\footnotesize Ansible}
+\cvtag{\footnotesize Git}
+\cvtag{\footnotesize Azure DevOps}
+\cvtag{\footnotesize GitLab}
+\cvtag{\footnotesize GitHub}
+\cvtag{\footnotesize Jenkins}
+\cvtag{\footnotesize CircleCI}
 
-  \vspace{-0.04cm}
+\vspace{0.5cm}
 
-  %=============================== FIRST COLUMN ===============================
+\smallskip
 
-  % details about vocational qualifications
-  \cvsection{Certifications}
+%===============================
 
-  \vspace{0.25cm}
+% tags for programming languages
+\cvsection{Languages}
 
-  \cvsubsection{Cloud/DevOps}
+\vspace{0.25cm}
 
-  \begin{itemize}[leftmargin=0.5cm]
-    \begin{small}
-      \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/9fa8d5c9941c306a}{Microsoft Certified: DevOps Engineer Expert}
-      \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/dfc55b2ee2422f60}{Microsoft Certified: Azure Administrator Associate}
-      \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/508432a7f7252b38}{Microsoft Certified: Azure Fundamentals}
-      \item \href{https://www.credly.com/badges/4d6f1742-7c27-4d07-ba0d-964210b6a2e5/public_url}{AWS Certified Solutions Architect - Associate}
-      \item \href{https://www.credly.com/badges/59c984ed-dce0-4716-9969-993f76808701/public_url}{AWS Certified SysOps Administrator - Associate}
-      \item \href{https://www.credly.com/badges/51e0bffd-6a77-4d74-adce-40c06015ce86/public_url}{AWS Certified Developer - Associate}
-      \item \href{https://www.credly.com/badges/5db53ec6-0fb1-4ae4-99c7-6a1b3ac22302/public_url}{AWS Certified Cloud Practitioner}
-      \item \href{https://www.credly.com/badges/01c9e4c4-97fa-4a7d-ab58-bf46955d4085}{Hashicorp Certified: Terraform Associate}
-    \end{small}
-  \end{itemize}
+\cvtag{\footnotesize YAML}
+\cvtag{\footnotesize JSON}
+\cvtag{\footnotesize HCL}
+\cvtag{\footnotesize Python}
+\cvtag{\footnotesize PowerShell}
+\cvtag{\footnotesize Bash}
+\cvtag{\footnotesize MATLAB}
+\cvtag{\footnotesize R}
+\cvtag{\footnotesize \LaTeX}
 
-  \vspace{0.25cm}
+\vspace{0.5cm}
 
-  \cvsubsection{Security}
+\smallskip
 
-  \begin{itemize}[leftmargin=0.5cm]
-    \begin{small}
-      \item \href{https://www.credly.com/badges/00ee07f4-0640-40a3-b4b5-5a6d65f5a2df}{NIST Cybersecurity Framework Professional Practitioner}
-      \item \href{https://www.credly.com/badges/357158a5-75ae-4649-97eb-cc1c9829b2f9}{CompTIA Security+}
-      \item \href{https://aspen.eccouncil.org/VerifyBadge?type=certification&a=UR85u9BGOO5V+b6Nq1cbrqvuDkKDQsqZVZzAAnDrtQc=}{EC-Council Certified Ethical Hacker}
-    \end{small}
-  \end{itemize}
+%===============================
 
-  \vspace{0.25cm}
+% tags for project management
+\cvsection{Project Management}
 
-  \cvsubsection{Artificial Intelligence \& Machine Learning}
+\vspace{0.25cm}
 
-  \begin{itemize}[leftmargin=0.5cm]
-    \begin{small}
-      \item \href{https://learn.microsoft.com/en-gb/users/jonbamber/credentials/dd17d03fc8e825ff}{Microsoft Certified: Azure AI Fundamentals}
-      \item \href{https://www.coursera.org/account/accomplishments/verify/DZ75HEAM5S43}{DeepLearning.AI: Machine Learning}
-      \item \href{https://www.coursera.org/account/accomplishments/specialization/93CPQS55488S}{DeepLearning.AI: Deep Learning Specialization}
-    \end{small}
-  \end{itemize}
+\cvtag{\footnotesize Agile/Scrum}
+\cvtag{\footnotesize Kanban}
+\cvtag{\footnotesize Azure Boards}
+\cvtag{\footnotesize Jira}
+\cvtag{\footnotesize Confluence}
+\cvtag{\footnotesize Slack}
+\cvtag{\footnotesize Teams}
 
-  \vspace{0.25cm}
+\vspace{0.5cm}
 
-  \smallskip
+\smallskip
 
-  %===============================
+%===============================
 
-  % details of university education
-  \cvsection{Education}
+% tags for hard skills
+\cvsection{Hard skills}
 
-  \vspace{0.25cm}
+\vspace{0.25cm}
 
-  \cvevent{\normalsize MSc Cloud Computing (\emph{ongoing})}{
-    \small
-    \href{https://www.mtu.ie/}{Munster Technological University}
-  }{}{}
-  \cvevent{\normalsize MRes Neuroinformatics}{
-    \small
-    \href{https://www.ed.ac.uk}{University of Edinburgh}
-  }{}{}
-  \cvevent{\normalsize MSc Computational Science}{
-    \small
-    \href{https://www.manchester.ac.uk}{University of Manchester}
-  }{}{}
-  \cvevent{\normalsize BSc Mathematics}{
-    \small
-    \href{https://www.manchester.ac.uk}{University of Manchester}
-  }{}{}
+\cvtag{\footnotesize Continuous Integration and Contiuous Delivery (CI/CD)}
+\cvtag{\footnotesize Automation}
+\cvtag{\footnotesize Infrastructure as Code (IaC)}
+\cvtag{\footnotesize Scripting}
+\cvtag{\footnotesize Configuration management}
+\cvtag{\footnotesize Containerisation}
+\cvtag{\footnotesize Documentation}
 
-  %=============================== SECOND COLUMN ===============================
+\vspace{0.5cm}
 
-  \switchcolumn
+\smallskip
 
-  % tags for DevOps tools
-  \cvsection{DevOps Tools}
+%===============================
 
-  \vspace{0.25cm}
+% tags for soft skills
+\cvsection{Soft skills}
 
-  \cvtag{\footnotesize Azure}
-  \cvtag{\footnotesize AWS}
-  \cvtag{\footnotesize Terraform}
-  \cvtag{\footnotesize ARM Templates}
-  \cvtag{\footnotesize CloudFormation}
-  \cvtag{\footnotesize Packer}
-  \cvtag{\footnotesize Docker}
-  \cvtag{\footnotesize Ansible}
-  \cvtag{\footnotesize Git}
-  \cvtag{\footnotesize Azure DevOps}
-  \cvtag{\footnotesize GitLab}
-  \cvtag{\footnotesize GitHub}
-  \cvtag{\footnotesize Jenkins}
-  \cvtag{\footnotesize CircleCI}
+\vspace{0.25cm}
 
-  \vspace{0.5cm}
-
-  \smallskip
-
-  %===============================
-
-  % tags for programming languages
-  \cvsection{Languages}
-
-  \vspace{0.25cm}
-
-  \cvtag{\footnotesize YAML}
-  \cvtag{\footnotesize JSON}
-  \cvtag{\footnotesize HCL}
-  \cvtag{\footnotesize Python}
-  \cvtag{\footnotesize PowerShell}
-  \cvtag{\footnotesize Bash}
-  \cvtag{\footnotesize MATLAB}
-  \cvtag{\footnotesize R}
-  \cvtag{\footnotesize \LaTeX}
-
-  \vspace{0.5cm}
-
-  \smallskip
-
-  %===============================
-
-  % tags for project management
-  \cvsection{Project Management}
-
-  \vspace{0.25cm}
-
-  \cvtag{\footnotesize Agile/Scrum}
-  \cvtag{\footnotesize Kanban}
-  \cvtag{\footnotesize Azure Boards}
-  \cvtag{\footnotesize Jira}
-  \cvtag{\footnotesize Confluence}
-  \cvtag{\footnotesize Slack}
-  \cvtag{\footnotesize Teams}
-
-  \vspace{0.5cm}
-
-  \smallskip
-
-  %===============================
-
-  % tags for hard skills
-  \cvsection{Hard skills}
-
-  \vspace{0.25cm}
-
-  \cvtag{\footnotesize Continuous Integration and Contiuous Delivery (CI/CD)}
-  \cvtag{\footnotesize Automation}
-  \cvtag{\footnotesize Infrastructure as Code (IaC)}
-  \cvtag{\footnotesize Scripting}
-  \cvtag{\footnotesize Configuration management}
-  \cvtag{\footnotesize Containerisation}
-  \cvtag{\footnotesize Documentation}
-
-  \vspace{0.5cm}
-
-  \smallskip
-
-  %===============================
-
-  % tags for soft skills
-  \cvsection{Soft skills}
-
-  \vspace{0.25cm}
-
-  \cvtag{\footnotesize Hard worker}
-  \cvtag{\footnotesize Clean coder}
-  \cvtag{\footnotesize Critical thinker}
-  \cvtag{\footnotesize Problem solver}
-  \cvtag{\footnotesize Excellent communicator}
-
-\end{paracol}
+\cvtag{\footnotesize Hard worker}
+\cvtag{\footnotesize Clean coder}
+\cvtag{\footnotesize Critical thinker}
+\cvtag{\footnotesize Problem solver}
+\cvtag{\footnotesize Excellent communicator}

--- a/tex/cv_sections/summary.tex
+++ b/tex/cv_sections/summary.tex
@@ -1,19 +1,19 @@
 \cvsection{Summary}
 
+\vspace{0.25cm}
+
 \begin{small}
+  I am a skilled DevOps Engineer based in Cardiff, specialising in designing and building Cloud solutions on Azure and AWS.
 
-  \vspace{0.25cm}
+  \vspace{0.5cm}
 
-  I am a Cardiff-based DevOps Engineer who builds Cloud solutions in Azure and AWS.
-  \vspace{0.25cm}
+  With extensive experience in Infrastructure as Code (IaC) and Continuous Integration \& Continuous Delivery (CI/CD) pipelines, I use leading DevOps tools and languages to build robust delivery workflows.
 
-  With years of experience implementing Infrastructure as Code (IaC) and Continuous Integration \& Continuous Delivery (CI/CD),
-  I am proficient in the main languages \& tools generally used in DevOps,
-  and I work well as part of collaborative Agile teams.
-  \vspace{0.25cm}
+  \vspace{0.5cm}
 
-  I also have a strong interest in Artificial Intelligence and Machine Learning (AI/ML),
-  with a background in mathematics, statistics, and informatics,
-  and I hope to apply my DevOps skills to MLOps roles in the future.
+  A strong advocate for Agile collaboration, I thrive in dynamic team environments.
 
+  \vspace{0.5cm}
+
+  Leveraging a strong background in Mathematics, Statistics, and Informatics, I am passionate about Artificial Intelligence and Machine Learning (AI/ML) and aspire to advance into MLOps roles, combining my DevOps expertise with cutting-edge AI technologies.
 \end{small}


### PR DESCRIPTION
This change restructures both the CV layout and the file hierarchy for TeX files.

The top level Tex file now references Tex files `page_1` and `page_2` which themselves then reference individual TeX files for each section, making it easier to update specific details.

Additionally, the placeholder variable names have been shortened so that any local PDF compilation better reflects the spacing of a pipeline-compiled one.